### PR TITLE
paymentUseCase.pay 기능 후처리 비동기 이벤트 처리

### DIFF
--- a/src/main/java/com/week4/concert/application/PaymentUseCase.java
+++ b/src/main/java/com/week4/concert/application/PaymentUseCase.java
@@ -4,6 +4,7 @@ import com.week4.concert.domain.concert.Concert;
 import com.week4.concert.domain.concert.ConcertService;
 import com.week4.concert.domain.payment.PaymentService;
 import com.week4.concert.domain.payment.event.PaymentEvent;
+import com.week4.concert.domain.payment.event.PaymentEventPublisher;
 import com.week4.concert.domain.reservation.ReservationService;
 import com.week4.concert.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PaymentUseCase {
 
-    private final ApplicationEventPublisher applicationEventPublisher;
     private final PaymentService paymentService;
     private final ReservationService reservationService;
     private final ConcertService concertService;
     private final UserService userService;
+    private final PaymentEventPublisher paymentEventPublisher;
 
     @Transactional
     public String pay(String reservationNumber, Long userId) {
@@ -36,7 +37,7 @@ public class PaymentUseCase {
 
         concertService.increaseReservationCount(reservedConcert.id());
 
-        applicationEventPublisher.publishEvent(new PaymentEvent(reservationNumber, reservedConcert, userId));
+        paymentEventPublisher.publishEvent(new PaymentEvent(reservationNumber, reservedConcert, userId));
 
         return "정상 결제되었습니다. 예약이 확정되었습니다.";
     }

--- a/src/main/java/com/week4/concert/application/PaymentUseCase.java
+++ b/src/main/java/com/week4/concert/application/PaymentUseCase.java
@@ -2,8 +2,8 @@ package com.week4.concert.application;
 
 import com.week4.concert.domain.concert.Concert;
 import com.week4.concert.domain.concert.ConcertService;
-import com.week4.concert.domain.payment.PaymentEvent;
 import com.week4.concert.domain.payment.PaymentService;
+import com.week4.concert.domain.payment.event.PaymentEvent;
 import com.week4.concert.domain.reservation.ReservationService;
 import com.week4.concert.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +31,10 @@ public class PaymentUseCase {
         userService.usePoint(userId, reservedConcert.price());
 
         paymentService.pay(reservationNumber, userId);
+
+        reservationService.finalizeConfirmation(reservationNumber,reservedConcert.title(),userId);
+
+        concertService.increaseReservationCount(reservedConcert.id());
 
         applicationEventPublisher.publishEvent(new PaymentEvent(reservationNumber, reservedConcert, userId));
 

--- a/src/main/java/com/week4/concert/domain/concert/ConcertService.java
+++ b/src/main/java/com/week4/concert/domain/concert/ConcertService.java
@@ -25,8 +25,12 @@ public class ConcertService {
     }
 
     public void increaseReservationCount(Long concertId) {
-        ConcertEntity concert = concertReader.getConcertById(concertId);
-        concert.setReservedCount(concert.getReservedCount()+1);
+        try {
+            ConcertEntity concert = concertReader.getConcertById(concertId);
+            concert.setReservedCount(concert.getReservedCount() + 1);
+        }catch (Exception e){
+            throw new RuntimeException("매진된 콘서트 입니다.");
+        }
     }
 
     public List<String> showAvailableConcertList() {

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEvent.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEvent.java
@@ -1,4 +1,4 @@
-package com.week4.concert.domain.payment;
+package com.week4.concert.domain.payment.event;
 
 import com.week4.concert.domain.concert.Concert;
 

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEventListener.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEventListener.java
@@ -1,4 +1,4 @@
-package com.week4.concert.domain.payment;
+package com.week4.concert.domain.payment.event;
 
 import com.week4.concert.admin.MessageService;
 import com.week4.concert.domain.concert.ConcertService;
@@ -7,7 +7,6 @@ import com.week4.concert.domain.reservation.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -22,31 +21,16 @@ public class PaymentEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    public void sendMessage(PaymentEvent event){
+    public void sendMessage(PaymentEvent event) {
         messageService.send();
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    public void removeActiveUser(PaymentEvent event){
+    public void removeActiveUser(PaymentEvent event) {
         queueService.removeActiveUser(event.userId());
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async
-    public void finalizeConfirmation(PaymentEvent event){
-        reservationService.finalizeConfirmation(
-                event.reservationNumber(),
-                event.reservedConcert().title(),
-                event.userId()
-              );
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async
-    public void increaseReservationCount(PaymentEvent event){
-        concertService.increaseReservationCount(event.reservedConcert().id());
-    }
 }
 
 

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEventListener.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEventListener.java
@@ -15,8 +15,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PaymentEventListener {
 
     private final MessageService messageService;
-    private final ReservationService reservationService;
-    private final ConcertService concertService;
     private final QueueService queueService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEventPublisher.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEventPublisher.java
@@ -1,0 +1,18 @@
+package com.week4.concert.domain.payment.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publishEvent(PaymentEvent event){
+
+        applicationEventPublisher.publishEvent(event);
+
+    }
+}

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEventPublisher.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEventPublisher.java
@@ -11,8 +11,6 @@ public class PaymentEventPublisher {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public void publishEvent(PaymentEvent event){
-
         applicationEventPublisher.publishEvent(event);
-
     }
 }

--- a/src/test/java/com/week4/concert/integrationTest/EventTest.java
+++ b/src/test/java/com/week4/concert/integrationTest/EventTest.java
@@ -1,0 +1,44 @@
+package com.week4.concert.integrationTest;
+
+import com.week4.concert.application.PaymentUseCase;
+import com.week4.concert.base.lockHandler.LockHandler;
+import com.week4.concert.domain.payment.PaymentService;
+import com.week4.concert.domain.queue.QueueService;
+import com.week4.concert.domain.reservation.ReservationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class EventTest {
+
+    @Autowired
+    private LockHandler lockHandler;
+
+    @Autowired
+    private PaymentUseCase paymentUseCase;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private QueueService queueService;
+
+
+
+    @BeforeEach
+    void resetRedis() {
+        lockHandler.reset();
+    }
+
+    @Test
+    @DisplayName("이벤트 정상 발행/처리 테스트")
+    void message_producing_and_consuming(){
+        reservationService.createTemporaryReservation("20241112.5.21",1L);
+        paymentUseCase.pay("20241112.5.21",1L);
+        assert queueService.checkUserStatus(1L) == "대기중인 유저가 아닙니다.";
+    }
+
+}


### PR DESCRIPTION
# Description 
> 기존 
- paymentUseCase.pay 기능은 지나치게 책임이 많음 
- 부차적이거나 외부적인 기능에서 예외발생시 주요 비지니스 로직까지 롤백됨
> 개선
- paymentUseCase.pay에서 부차적인 로직들은 application event로 비동기 처리
- event에서의 실패나 예외는 주요 비지니스로직에 영향을 주지 못함


# 추가/변경된 파일 
- PaymentEvent 
- PaymentEventListener 
- PaymentEventPublisher 
- PaymentUseCase
- EventTest
- MessageMockController
- MessageService


# Test
- EventTest 를 통해 정상적인 분리 확인
- 외부api 호출을 모킹하는MessageMockController를 사용하여 
고의적인 이벤트 예외를 발생시켰지만 
다른 이벤트와 상위 호출자 로직에 영향을 주지 않고 정장적으로 커밋됨