### PR TITLE
paymentUseCase.pay 기능 후처리 Kafka 비동기 메세징 처

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//Redisson
 	implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.27.2'
+	//kafka
+	implementation 'org.springframework.kafka:spring-kafka'
 
 }
 

--- a/src/main/java/com/week4/concert/application/PaymentUseCase.java
+++ b/src/main/java/com/week4/concert/application/PaymentUseCase.java
@@ -37,7 +37,7 @@ public class PaymentUseCase {
 
         concertService.increaseReservationCount(reservedConcert.id());
 
-        paymentEventPublisher.publishEvent(new PaymentEvent(reservationNumber, reservedConcert, userId));
+        paymentEventPublisher.publishEvent(userId);
 
         return "정상 결제되었습니다. 예약이 확정되었습니다.";
     }

--- a/src/main/java/com/week4/concert/base/config/message/KafkaConsumerConfig.java
+++ b/src/main/java/com/week4/concert/base/config/message/KafkaConsumerConfig.java
@@ -1,0 +1,35 @@
+package com.week4.concert.base.config.message;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "group_1");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        return factory;
+    }
+}

--- a/src/main/java/com/week4/concert/base/config/message/KafkaProducerConfig.java
+++ b/src/main/java/com/week4/concert/base/config/message/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package com.week4.concert.base.config.message;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        DefaultKafkaProducerFactory<String, Object> producerFactory = new DefaultKafkaProducerFactory<>(config);
+        //producerFactory.setTransactionIdPrefix("tx-");
+
+        return producerFactory;
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEventListener.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEventListener.java
@@ -4,29 +4,36 @@ import com.week4.concert.admin.MessageService;
 import com.week4.concert.domain.concert.ConcertService;
 import com.week4.concert.domain.queue.QueueService;
 import com.week4.concert.domain.reservation.ReservationService;
+import com.week4.concert.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentEventListener {
 
     private final MessageService messageService;
     private final QueueService queueService;
+    private final ReservationService reservationService;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    public void sendMessage(PaymentEvent event) {
+    @KafkaListener(topics = "payment", groupId = "payment-message")
+    public void sendMessage(String data) {
         messageService.send();
+        log.info(":: 전송완료 ::");
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
-    public void removeActiveUser(PaymentEvent event) {
-        queueService.removeActiveUser(event.userId());
+    @KafkaListener(topics = "payment", groupId = "payment-queue")
+    public void removeActiveUser(String userId) {
+        queueService.removeActiveUser(Long.parseLong(userId));
+        log.info(":: 대기열 해제 완료 ::");
     }
 
 }

--- a/src/main/java/com/week4/concert/domain/payment/event/PaymentEventPublisher.java
+++ b/src/main/java/com/week4/concert/domain/payment/event/PaymentEventPublisher.java
@@ -2,15 +2,16 @@ package com.week4.concert.domain.payment.event;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class PaymentEventPublisher {
 
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    public void publishEvent(PaymentEvent event){
-        applicationEventPublisher.publishEvent(event);
+    public void publishEvent(Long userId){
+        kafkaTemplate.send("payment", userId.toString());
     }
 }

--- a/src/test/java/com/week4/concert/integrationTest/EventTest.java
+++ b/src/test/java/com/week4/concert/integrationTest/EventTest.java
@@ -1,0 +1,44 @@
+package com.week4.concert.integrationTest;
+
+import com.week4.concert.application.PaymentUseCase;
+import com.week4.concert.base.lockHandler.LockHandler;
+import com.week4.concert.domain.payment.PaymentService;
+import com.week4.concert.domain.queue.QueueService;
+import com.week4.concert.domain.reservation.ReservationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class EventTest {
+
+    @Autowired
+    private LockHandler lockHandler;
+
+    @Autowired
+    private PaymentUseCase paymentUseCase;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private QueueService queueService;
+
+
+
+    @BeforeEach
+    void resetRedis() {
+        lockHandler.reset();
+    }
+
+    @Test
+    @DisplayName("이벤트 정상 발행/처리 테스트")
+    void message_producing_and_consuming(){
+        reservationService.createTemporaryReservation("20241112.5.21",1L);
+        paymentUseCase.pay("20241112.5.21",1L);
+        assert queueService.checkUserStatus(1L) == "대기중인 유저가 아닙니다.";
+    }
+
+}


### PR DESCRIPTION
# Description 
> 기존 
- paymentUseCase.pay 기능은 지나치게 책임이 많음 
- 부차적이거나 외부적인 기능에서 예외발생시 주요 비지니스 로직까지 롤백됨
- ApplicationEvent로 책임을 분리

> 개선
- 서비스 분산을 대비하여 Kafka 적용
- paymentUseCase.pay에서 부차적인 로직들은 Kafka 메세지를 발행하여 비동기 처리
- 메세지에서 파생된 이벤트 실패나 예외는 주요 비지니스로직에 영향을 주지 못함
-  producerFactory.setTransactionIdPrefix("tx-") : 프리픽스를 설정하여 
주요 비지니스 commit 후 message 발행 보장


# 추가/변경된 파일 
- PaymentEvent 
- PaymentEventListener 
- PaymentEventPublisher 
- PaymentUseCase
- EventTest
- MessageMockController
- MessageService
- PaymentEvent Publisher/Listener 
- Kafka producer/consumer config 


# Test
- EventTest 를 통해 정상적인 분리 확인
- 외부api 호출을 모킹하는MessageMockController를 사용하여 
고의적인 이벤트 예외를 발생시켰지만 
다른 이벤트와 상위 호출자 로직에 영향을 주지 않고 정장적으로 커밋됨